### PR TITLE
Measurement cursors and markers

### DIFF
--- a/lumberjack.pro
+++ b/lumberjack.pro
@@ -47,6 +47,7 @@ SOURCES += \
     src/lumberjack_version.cpp \
     src/plot_curve.cpp \
     src/plot_legend.cpp \
+    src/plot_marker.cpp \
     src/plot_widget.cpp \
     src/main.cpp \
     src/mainwindow.cpp \
@@ -78,6 +79,7 @@ HEADERS += \
     src/lumberjack_version.hpp \
     src/plot_curve.hpp \
     src/plot_legend.hpp \
+    src/plot_marker.hpp \
     src/plot_panner.hpp \
     src/plot_widget.hpp \
     src/plugins/plugin_base.hpp \

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -261,9 +261,11 @@ void MainWindow::initSignalsSlots()
 void MainWindow::initStatusBar()
 {
     ui->statusbar->showMessage("lumberjack");
-
-    ui->statusbar->addPermanentWidget(&dt_pos);
+    ui->statusbar->addWidget(&dt_pos);
     dt_pos.setHidden(true);
+
+    ui->statusbar->addWidget(&dy_pos);
+    dy_pos.setHidden(true);
 
     ui->statusbar->addPermanentWidget(&t_pos);
     ui->statusbar->addPermanentWidget(&y1_pos);
@@ -338,15 +340,19 @@ void MainWindow::updateCursorPos(double t, double y1, double y2)
     y2_pos.setText("y2: " + fixedWidthNumber(y2));
 }
 
-void MainWindow::updateDifferences(double dt)
+void MainWindow::updateDifferences(double dt, double dy)
 {
     dt_pos.setHidden(false);
     dt_pos.setText("dt: " + fixedWidthNumber(dt));
+
+    dy_pos.setHidden(std::isnan(dy));
+    dy_pos.setText("dy: " + fixedWidthNumber(dy));
 }
 
 void MainWindow::hideDifferences()
 {
     dt_pos.setHidden(true);
+    dy_pos.setHidden(true);
 }
 
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -262,6 +262,9 @@ void MainWindow::initStatusBar()
 {
     ui->statusbar->showMessage("lumberjack");
 
+    ui->statusbar->addPermanentWidget(&dt_pos);
+    dt_pos.setHidden(true);
+
     ui->statusbar->addPermanentWidget(&t_pos);
     ui->statusbar->addPermanentWidget(&y1_pos);
     ui->statusbar->addPermanentWidget(&y2_pos);
@@ -333,6 +336,17 @@ void MainWindow::updateCursorPos(double t, double y1, double y2)
     t_pos.setText("t: " + fixedWidthNumber(t));
     y1_pos.setText("y1: " + fixedWidthNumber(y1));
     y2_pos.setText("y2: " + fixedWidthNumber(y2));
+}
+
+void MainWindow::updateDifferences(double dt)
+{
+    dt_pos.setHidden(false);
+    dt_pos.setText("dt: " + fixedWidthNumber(dt));
+}
+
+void MainWindow::hideDifferences()
+{
+    dt_pos.setHidden(true);
 }
 
 
@@ -457,6 +471,8 @@ void MainWindow::addPlot()
 
     // Connect signals/slots for the new plot
     connect(plot, &PlotWidget::cursorPositionChanged, this, &MainWindow::updateCursorPos);
+    connect(plot, &PlotWidget::markerAdded, this, &MainWindow::updateDifferences);
+    connect(plot, &PlotWidget::markersRemoved, this, &MainWindow::hideDifferences);
     connect(plot, &PlotWidget::viewChanged, this, &MainWindow::onTimescaleChanged);
     connect(plot, &PlotWidget::viewChanged, &timelineView, &TimelineWidget::updateViewLimits);
     connect(plot, &PlotWidget::timestampLimitsChanged, &timelineView, &TimelineWidget::updateTimeLimits);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -260,7 +260,6 @@ void MainWindow::initSignalsSlots()
  */
 void MainWindow::initStatusBar()
 {
-    ui->statusbar->showMessage("lumberjack");
     ui->statusbar->addWidget(&dt_pos);
     dt_pos.setHidden(true);
 
@@ -340,6 +339,11 @@ void MainWindow::updateCursorPos(double t, double y1, double y2)
     y2_pos.setText("y2: " + fixedWidthNumber(y2));
 }
 
+/**
+ * @brief MainWindow::updateDifferences - callback to display the delta values between two points in the status bar
+ * @param dt
+ * @param dy - set to NaN to hide dy text
+ */
 void MainWindow::updateDifferences(double dt, double dy)
 {
     dt_pos.setHidden(false);
@@ -349,6 +353,9 @@ void MainWindow::updateDifferences(double dt, double dy)
     dy_pos.setText("dy: " + fixedWidthNumber(dy));
 }
 
+/**
+ * @brief MainWindow::hideDifferences - callback to hide the delta values in the status bar when no markers are present
+ */
 void MainWindow::hideDifferences()
 {
     dt_pos.setHidden(true);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -31,6 +31,8 @@ public slots:
 
     void onTimescaleChanged(const QwtInterval &view);
     void updateCursorPos(double t, double y1, double y2);
+    void updateDifferences(double dt);
+    void hideDifferences();
     void loadDataFromFile(QString filename = QString());
 
 protected:
@@ -72,6 +74,8 @@ private:
     QLabel t_pos;
     QLabel y1_pos;
     QLabel y2_pos;
+
+    QLabel dt_pos;
 
     DataviewWidget dataView;
     StatsWidget statsView;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -31,7 +31,7 @@ public slots:
 
     void onTimescaleChanged(const QwtInterval &view);
     void updateCursorPos(double t, double y1, double y2);
-    void updateDifferences(double dt);
+    void updateDifferences(double dt, double dy);
     void hideDifferences();
     void loadDataFromFile(QString filename = QString());
 
@@ -76,6 +76,7 @@ private:
     QLabel y2_pos;
 
     QLabel dt_pos;
+    QLabel dy_pos;
 
     DataviewWidget dataView;
     StatsWidget statsView;

--- a/src/plot_marker.cpp
+++ b/src/plot_marker.cpp
@@ -1,0 +1,7 @@
+#include "plot_marker.hpp"
+
+PlotMarker::PlotMarker(QSharedPointer<PlotCurve> plotCurve)
+    : QwtPlotMarker(), curve(plotCurve)
+{
+
+}

--- a/src/plot_marker.hpp
+++ b/src/plot_marker.hpp
@@ -1,0 +1,22 @@
+#ifndef PLOT_MARKER_H
+#define PLOT_MARKER_H
+
+#include <qwt_plot_marker.h>
+
+#include "plot_curve.hpp"
+
+/*
+ * Custom subclass of QwtPlotMarker to keep track of which curve the marker is assigned to
+ */
+
+class PlotMarker : public QwtPlotMarker
+{
+public:
+    PlotMarker(QSharedPointer<PlotCurve> plotCurve = nullptr);
+
+    bool hasCurve() { return !curve.isNull(); }
+
+    QSharedPointer<PlotCurve> curve;
+};
+
+#endif // PLOT_MARKER_H

--- a/src/plot_widget.cpp
+++ b/src/plot_widget.cpp
@@ -1102,6 +1102,16 @@ bool PlotWidget::eventFilter(QObject *target, QEvent *event)
 
             break;
         }
+        case QEvent::KeyPress:
+        {
+            const QKeyEvent *keyEvent = dynamic_cast<QKeyEvent*>(event);
+
+            if (keyEvent && keyEvent->key() == Qt::Key_Space && crosshair)
+            {
+                this->addMarker(crosshair->xValue());
+            }
+            break;
+        }
         default:
             break;
         }

--- a/src/plot_widget.cpp
+++ b/src/plot_widget.cpp
@@ -314,6 +314,8 @@ void PlotWidget::onContextMenu(const QPoint &pos)
     QPoint canvas_pos = canvas()->mapFromGlobal(mapToGlobal(pos));
 
     double timestamp = canvasMap(QwtPlot::xBottom).invTransform(canvas_pos.x());
+    double y1Val = canvasMap(QwtPlot::yLeft).invTransform(canvas_pos.y());
+    double y2Val = canvasMap(QwtPlot::yRight).invTransform(canvas_pos.y());
 
     // Fit / zoom submenu
     QMenu *fitMenu = new QMenu(tr("Fit"), &menu);
@@ -472,6 +474,7 @@ void PlotWidget::onContextMenu(const QPoint &pos)
     else if (action == clearMarkers)
     {
         removeAllMarkers();
+        emit markersRemoved();
     }
     else if (action == syncAction)
     {
@@ -497,7 +500,7 @@ void PlotWidget::addMarker(double timestamp)
     QwtPlotMarker *marker = new QwtPlotMarker();
 
     // TODO: Custom text
-    marker->setLabel(QString("---"));
+    marker->setLabel("#"+QString::number(markers.size()));
 
     // TODO: Custom line color, style, etc
 
@@ -509,6 +512,14 @@ void PlotWidget::addMarker(double timestamp)
     marker->attach(this);
 
     markers.append(marker);
+
+    double dt = 0;
+    if (markers.size() > 1)
+    {
+        dt = timestamp - markers.at(markers.size()-2)->xValue();
+    }
+
+    emit markerAdded(dt);
 
     replot();
 }
@@ -530,6 +541,8 @@ void PlotWidget::removeAllMarkers()
     }
 
     markers.clear();
+
+    // Hide dt
 
     replot();
 }

--- a/src/plot_widget.hpp
+++ b/src/plot_widget.hpp
@@ -8,13 +8,12 @@
 #include <qwt_plot_zoomer.h>
 #include <qwt_plot_panner.h>
 #include <qwt_legend.h>
-#include <qwt_plot_marker.h>
 #include <qwt_plot_grid.h>
-#include <qwt_plot_marker.h>
 
 #include "plot_legend.hpp"
 #include "plot_panner.hpp"
 #include "plot_curve.hpp"
+#include "plot_marker.hpp"
 
 
 class PlotWidget : public QwtPlot
@@ -63,7 +62,7 @@ public slots:
     bool removeSeries(QString label);
     void removeAllSeries();
 
-    void addMarker(double timestamp, double value = std::numeric_limits<double>::quiet_NaN(), int axis_id = QwtPlot::yLeft);
+    void addMarker(double timestamp, QSharedPointer<PlotCurve> curve = nullptr);
     void removeAllMarkers();
 
     void autoScale(int axis_id = yBoth);
@@ -151,7 +150,7 @@ protected:
     QList<QSharedPointer<PlotCurve>> curves;
 
     // List of markers attached to this widget
-    QList<QwtPlotMarker*> markers;
+    QList<PlotMarker*> markers;
 
     QSharedPointer<PlotCurve> tracking_curve;
 

--- a/src/plot_widget.hpp
+++ b/src/plot_widget.hpp
@@ -49,7 +49,7 @@ signals:
 
     void cursorPositionChanged(double &t, double &y1, double &y2);
 
-    void markerAdded(double &dt);
+    void markerAdded(double dt, double dy);
     void markersRemoved();
 
 public slots:
@@ -63,7 +63,7 @@ public slots:
     bool removeSeries(QString label);
     void removeAllSeries();
 
-    void addMarker(double timestamp);
+    void addMarker(double timestamp, double value = std::numeric_limits<double>::quiet_NaN(), int axis_id = QwtPlot::yLeft);
     void removeAllMarkers();
 
     void autoScale(int axis_id = yBoth);

--- a/src/plot_widget.hpp
+++ b/src/plot_widget.hpp
@@ -49,6 +49,9 @@ signals:
 
     void cursorPositionChanged(double &t, double &y1, double &y2);
 
+    void markerAdded(double &dt);
+    void markersRemoved();
+
 public slots:
     int getHorizontalPixels(void) const;
 

--- a/ui/dataview_widget.ui
+++ b/ui/dataview_widget.ui
@@ -34,6 +34,9 @@
    </item>
    <item row="1" column="0">
     <widget class="DataViewTree" name="treeWidget">
+     <property name="editTriggers">
+      <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+     </property>
      <column>
       <property name="text">
        <string notr="true">1</string>

--- a/ui/stats_view.ui
+++ b/ui/stats_view.ui
@@ -15,7 +15,11 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QTableWidget" name="statsTable"/>
+    <widget class="QTableWidget" name="statsTable">
+     <property name="editTriggers">
+      <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
 * https://github.com/SchrodingersGat/lumberjack/issues/91 - Adds timestamp measurement cursors, displaying the difference between the last two points in the status bar.
 * When tracking a curve, adds measurement marker instead. Also displays difference (including y value) between last two points.
     * Works for curves on different axes, between a timestamp cursor and a marker, etc.
 * Set some tables as Read-only