### PR TITLE
Fix dataseries with all 0s from breaking the axis scaling 

### DIFF
--- a/src/plot_widget.cpp
+++ b/src/plot_widget.cpp
@@ -1792,7 +1792,7 @@ void PlotWidget::autoScale(int axisId, QwtInterval interval)
     double max = interval.maxValue();
 
     // Account for the values being "the same"
-    if (min == max)
+    if (abs(max-min) <= __DBL_MIN__)
     {
         min -= 0.5f;
         max += 0.5f;


### PR DESCRIPTION
the autoscaling function checks if min == max, however getMaximumValue always returns a value equal to or greater than __DBL_MIN__ 

this means that the 
```
if (min == max)
```
check is failing.
  

Due to this, data series that only have zero values are attempting to scale to a y axis of [0, 2.22E-308], which qwt plot can not handle.