### PR TITLE
Add math traces feature

### DIFF
--- a/lumberjack.pro
+++ b/lumberjack.pro
@@ -45,6 +45,10 @@ SOURCES += \
     src/lumberjack_debug.cpp \
     src/lumberjack_settings.cpp \
     src/lumberjack_version.cpp \
+    src/math_data_series.cpp \
+    src/math_data_source.cpp \
+    src/math_expression_parser.cpp \
+    src/math_trace_computer.cpp \
     src/plot_curve.cpp \
     src/plot_legend.cpp \
     src/plot_marker.cpp \
@@ -60,6 +64,7 @@ SOURCES += \
     src/widgets/dataview_tree.cpp \
     src/widgets/dataview_widget.cpp \
     src/widgets/debug_widget.cpp \
+    src/widgets/math_trace_dialog.cpp \
     src/widgets/plot_sampler.cpp \
     src/widgets/plugins_dialog.cpp \
     src/widgets/series_editor_dialog.cpp \
@@ -77,6 +82,10 @@ HEADERS += \
     src/lumberjack_debug.hpp \
     src/lumberjack_settings.hpp \
     src/lumberjack_version.hpp \
+    src/math_data_series.hpp \
+    src/math_data_source.hpp \
+    src/math_expression_parser.hpp \
+    src/math_trace_computer.hpp \
     src/plot_curve.hpp \
     src/plot_legend.hpp \
     src/plot_marker.hpp \
@@ -93,6 +102,7 @@ HEADERS += \
     src/widgets/dataview_tree.hpp \
     src/widgets/dataview_widget.hpp \
     src/widgets/debug_widget.hpp \
+    src/widgets/math_trace_dialog.hpp \
     src/widgets/plot_sampler.hpp \
     src/widgets/plugins_dialog.hpp \
     src/widgets/series_editor_dialog.hpp \
@@ -116,6 +126,7 @@ FORMS += \
     ui/dataview_widget.ui \
     ui/debug_widget.ui \
     ui/mainwindow.ui \
+    ui/math_trace_dialog.ui \
     ui/plugins_dialog.ui \
     ui/stats_view.ui
 

--- a/src/data_series.cpp
+++ b/src/data_series.cpp
@@ -392,6 +392,7 @@ double DataSeries::getNewestValue() const
 
 double DataSeries::getMinimumValue() const
 {
+    if (size() == 0) return 0.0;
     return getMinimumValue(getOldestTimestamp(), getNewestTimestamp());
 }
 
@@ -425,6 +426,7 @@ double DataSeries::getMinimumValue(double t_min, double t_max) const
 
 double DataSeries::getMaximumValue() const
 {
+    if (size() == 0) return 0.0;
     return getMaximumValue(getOldestTimestamp(), getNewestTimestamp());
 }
 
@@ -502,6 +504,7 @@ double DataSeries::getValueAtTime(double timestamp, InterpolationMode mode) cons
 
 double DataSeries::getMeanValue(void) const
 {
+    if (size() == 0) return 0.0;
     return getMeanValue(getOldestTimestamp(), getNewestTimestamp());
 }
 
@@ -539,6 +542,7 @@ double DataSeries::getMeanValue(double t_min, double t_max) const
 
 uint64_t DataSeries::getIndexForTimestamp(double t, SearchDirection direction) const
 {
+    if (size() == 0) return 0;
 
     if (t < getOldestTimestamp())
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -22,6 +22,7 @@
 
 #include "plugins_dialog.hpp"
 #include "about_dialog.hpp"
+#include "math_trace_dialog.hpp"
 
 #include "plugin_registry.hpp"
 
@@ -196,6 +197,7 @@ void MainWindow::initMenus()
 
     // Graphs menu
     connect(ui->action_Add_Graph, &QAction::triggered, this, &MainWindow::addPlot);
+    connect(ui->action_Math_Trace, &QAction::triggered, this, &MainWindow::showMathTraceDialog);
 
     // Help menu
     connect(ui->action_About, &QAction::triggered, this, &MainWindow::showAboutInfo);
@@ -623,4 +625,10 @@ void MainWindow::toggleStatisticsView(void)
 
         ui->action_Statistics->setChecked(true);
     }
+}
+
+void MainWindow::showMathTraceDialog()
+{
+    MathTraceDialog dialog(this);
+    dialog.exec();
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -62,6 +62,8 @@ protected slots:
     void addPlot();
     void removePlot(QSharedPointer<PlotWidget> plot);
 
+    void showMathTraceDialog(void);
+
     void hideDockedWidget(QWidget *widget);
 
     void seriesRemoved(DataSeriesPointer series);

--- a/src/math_data_series.cpp
+++ b/src/math_data_series.cpp
@@ -1,0 +1,23 @@
+#include "math_data_series.hpp"
+
+MathDataSeries::MathDataSeries(QString label,
+                               QString expression,
+                               QMap<QString, DataSeriesPointer> variableMapping)
+    : DataSeries("Math Traces", label),
+      mathExpression(expression),
+      inputSeries(variableMapping)
+{
+}
+
+MathDataSeries::~MathDataSeries()
+{
+}
+
+DataSeriesPointer MathDataSeries::getInputSeries(const QString& variable) const
+{
+    if (inputSeries.contains(variable))
+    {
+        return inputSeries[variable];
+    }
+    return DataSeriesPointer();
+}

--- a/src/math_data_series.hpp
+++ b/src/math_data_series.hpp
@@ -1,0 +1,64 @@
+#ifndef MATH_DATA_SERIES_HPP
+#define MATH_DATA_SERIES_HPP
+
+#include "data_series.hpp"
+#include <QMap>
+
+/**
+ * @brief The MathDataSeries class represents a computed data series
+ *
+ * This class extends DataSeries to store series computed from mathematical
+ * expressions applied to other series. It stores:
+ * - The mathematical expression used
+ * - References to input series
+ * - Variable name mappings
+ * - The computed result data points
+ */
+class MathDataSeries : public DataSeries
+{
+    Q_OBJECT
+
+public:
+    /**
+     * @brief Create a math data series
+     * @param label Name for this computed series
+     * @param expression Mathematical expression (e.g., "a - b")
+     * @param variableMapping Map of variable names to input series (e.g., {"a": seriesPtr1, "b": seriesPtr2})
+     */
+    MathDataSeries(QString label,
+                   QString expression,
+                   QMap<QString, DataSeriesPointer> variableMapping);
+
+    virtual ~MathDataSeries();
+
+    /**
+     * @brief Get the mathematical expression
+     */
+    QString getExpression() const { return mathExpression; }
+
+    /**
+     * @brief Get the variable mapping
+     */
+    QMap<QString, DataSeriesPointer> getVariableMapping() const { return inputSeries; }
+
+    /**
+     * @brief Get a specific input series by variable name
+     */
+    DataSeriesPointer getInputSeries(const QString& variable) const;
+
+    /**
+     * @brief Check if this series is computed (always true for MathDataSeries)
+     */
+    bool isComputed() const { return true; }
+
+private:
+    //! The mathematical expression used to compute this series
+    QString mathExpression;
+
+    //! Map of variable names to input series
+    QMap<QString, DataSeriesPointer> inputSeries;
+};
+
+typedef QSharedPointer<MathDataSeries> MathDataSeriesPointer;
+
+#endif // MATH_DATA_SERIES_HPP

--- a/src/math_data_source.cpp
+++ b/src/math_data_source.cpp
@@ -1,0 +1,65 @@
+#include "math_data_source.hpp"
+#include "data_source_manager.hpp"
+
+// Initialize static instance
+MathDataSource* MathDataSource::instance = nullptr;
+static DataSourcePointer instancePtr;
+
+MathDataSource::MathDataSource()
+    : DataSource("Math Traces", "Math Traces", "Computed mathematical traces")
+{
+}
+
+MathDataSource* MathDataSource::getInstance()
+{
+    if (instance == nullptr)
+    {
+        instance = new MathDataSource();
+        instancePtr = DataSourcePointer(instance, [](DataSource*){});  // Empty deleter - we manage lifecycle
+    }
+
+    // Always ensure we're registered (handles case where source was deleted from UI)
+    DataSourceManager* manager = DataSourceManager::getInstance();
+    DataSourcePointer existingSource = manager->getSourceByLabel("Math Traces");
+
+    if (!existingSource)
+    {
+        // Re-register if we were removed
+        manager->addSource(instancePtr);
+    }
+
+    return instance;
+}
+
+bool MathDataSource::addMathSeries(MathDataSeriesPointer series)
+{
+    if (!series)
+    {
+        return false;
+    }
+
+    // Use the base class method to add the series
+    return addSeries(series, true);  // auto_color = true
+}
+
+bool MathDataSource::removeMathSeries(const QString& label)
+{
+    return removeSeriesByLabel(label, true);
+}
+
+MathDataSeriesPointer MathDataSource::getMathSeries(const QString& label)
+{
+    DataSeriesPointer series = getSeriesByLabel(label);
+    if (!series)
+    {
+        return MathDataSeriesPointer();
+    }
+
+    // Cast to MathDataSeriesPointer
+    return series.dynamicCast<MathDataSeries>();
+}
+
+bool MathDataSource::hasMathSeries(const QString& label)
+{
+    return getSeriesByLabel(label) != nullptr;
+}

--- a/src/math_data_source.hpp
+++ b/src/math_data_source.hpp
@@ -1,0 +1,59 @@
+#ifndef MATH_DATA_SOURCE_HPP
+#define MATH_DATA_SOURCE_HPP
+
+#include "data_source.hpp"
+#include "math_data_series.hpp"
+
+/**
+ * @brief The MathDataSource class is a special data source for computed math traces
+ *
+ * This is a singleton data source that holds all math traces created by the user.
+ * It appears as a separate category in the data view.
+ */
+class MathDataSource : public DataSource
+{
+    Q_OBJECT
+
+public:
+    /**
+     * @brief Get the singleton instance
+     */
+    static MathDataSource* getInstance();
+
+    /**
+     * @brief Add a computed math series
+     * @param series The MathDataSeries to add
+     * @return true if added successfully
+     */
+    bool addMathSeries(MathDataSeriesPointer series);
+
+    /**
+     * @brief Remove a math series by label
+     * @param label Name of the series to remove
+     * @return true if removed successfully
+     */
+    bool removeMathSeries(const QString& label);
+
+    /**
+     * @brief Get a math series by label
+     * @param label Name of the series
+     * @return Pointer to the series, or null if not found
+     */
+    MathDataSeriesPointer getMathSeries(const QString& label);
+
+    /**
+     * @brief Check if a math series with this label exists
+     * @param label Name to check
+     * @return true if exists
+     */
+    bool hasMathSeries(const QString& label);
+
+private:
+    // Private constructor for singleton
+    MathDataSource();
+
+    // Singleton instance
+    static MathDataSource* instance;
+};
+
+#endif // MATH_DATA_SOURCE_HPP

--- a/src/math_expression_parser.cpp
+++ b/src/math_expression_parser.cpp
@@ -1,0 +1,608 @@
+#include "math_expression_parser.hpp"
+#include <QRegularExpression>
+#include <QDebug>
+
+MathExpressionParser::MathExpressionParser()
+{
+}
+
+MathExpressionParser::~MathExpressionParser()
+{
+}
+
+/**
+ * @brief Parse a mathematical expression into an internal tree structure
+ *
+ * This is a two-phase process:
+ * 1. Tokenization: Convert string into tokens (numbers, operators, functions, etc.)
+ * 2. Parsing: Build expression tree using recursive descent parser
+ *
+ * The parser handles operator precedence through function hierarchy:
+ * - parseExpression: +, - (lowest precedence)
+ * - parseTerm: *, /
+ * - parsePower: ^ (right-associative)
+ * - parseUnary: unary -
+ * - parsePrimary: numbers, variables, functions, parentheses
+ *
+ * @param expression The mathematical expression string (e.g., "a * b + c")
+ * @return true if parsing succeeded, false otherwise (check getError())
+ */
+bool MathExpressionParser::parse(const QString& expression)
+{
+    errorMessage.clear();
+    rootNode.reset();
+
+    if (expression.trimmed().isEmpty())
+    {
+        errorMessage = "Empty expression";
+        return false;
+    }
+
+    // Phase 1: Tokenize the expression into meaningful units
+    QList<Token> tokens = tokenize(expression);
+
+    if (!errorMessage.isEmpty())
+    {
+        return false;
+    }
+
+    // Phase 2: Parse tokens into expression tree using recursive descent
+    int pos = 0;
+    try
+    {
+        rootNode = parseExpression(tokens, pos);
+
+        // Ensure we consumed all tokens (except the END marker)
+        if (pos < tokens.size() && tokens[pos].type != Token::TOKEN_END)
+        {
+            errorMessage = QString("Unexpected token at position %1: %2").arg(pos).arg(tokens[pos].value);
+            return false;
+        }
+    }
+    catch (const QString& error)
+    {
+        errorMessage = error;
+        return false;
+    }
+
+    return rootNode != nullptr;
+}
+
+/**
+ * @brief Tokenize a mathematical expression string
+ *
+ * Converts the input string into a list of tokens for parsing.
+ * Handles:
+ * - Numbers (integers and decimals like 3.14)
+ * - Variables (alphanumeric + underscore, e.g., "rpm1", "temp_sensor")
+ * - Functions (abs, sqrt, log, exp, sin, cos, tan)
+ * - Constants (pi, e)
+ * - Operators (+, -, *, /, ^)
+ * - Parentheses and commas
+ *
+ * @param expression The input expression string
+ * @return List of tokens, or empty list on error (check errorMessage)
+ */
+QList<MathExpressionParser::Token> MathExpressionParser::tokenize(const QString& expression)
+{
+    QList<Token> tokens;
+    QString expr = expression.trimmed();
+    int i = 0;
+
+    while (i < expr.length())
+    {
+        QChar c = expr[i];
+
+        // Skip whitespace
+        if (c.isSpace())
+        {
+            i++;
+            continue;
+        }
+
+        // Numbers (including decimals)
+        if (c.isDigit() || c == '.')
+        {
+            int start = i;
+            while (i < expr.length() && (expr[i].isDigit() || expr[i] == '.'))
+            {
+                i++;
+            }
+
+            Token token;
+            token.type = Token::TOKEN_NUMBER;
+            token.value = expr.mid(start, i - start);
+            token.numberValue = token.value.toDouble();
+            tokens.append(token);
+            continue;
+        }
+
+        // Variables and functions (start with letter)
+        if (c.isLetter())
+        {
+            int start = i;
+            while (i < expr.length() && (expr[i].isLetterOrNumber() || expr[i] == '_'))
+            {
+                i++;
+            }
+
+            Token token;
+            token.value = expr.mid(start, i - start);
+
+            // Check if it's a known function
+            if (token.value == "abs" || token.value == "sqrt" || token.value == "log" ||
+                token.value == "exp" || token.value == "sin" || token.value == "cos" ||
+                token.value == "tan")
+            {
+                token.type = Token::TOKEN_FUNCTION;
+            }
+            // Check if it's a constant
+            else if (token.value == "pi")
+            {
+                token.type = Token::TOKEN_NUMBER;
+                token.numberValue = M_PI;
+            }
+            else if (token.value == "e")
+            {
+                token.type = Token::TOKEN_NUMBER;
+                token.numberValue = M_E;
+            }
+            else
+            {
+                token.type = Token::TOKEN_VARIABLE;
+            }
+
+            tokens.append(token);
+            continue;
+        }
+
+        // Operators
+        if (isOperator(c))
+        {
+            Token token;
+            token.type = Token::TOKEN_OPERATOR;
+            token.value = c;
+            tokens.append(token);
+            i++;
+            continue;
+        }
+
+        // Parentheses
+        if (c == '(')
+        {
+            Token token;
+            token.type = Token::TOKEN_LEFT_PAREN;
+            token.value = c;
+            tokens.append(token);
+            i++;
+            continue;
+        }
+
+        if (c == ')')
+        {
+            Token token;
+            token.type = Token::TOKEN_RIGHT_PAREN;
+            token.value = c;
+            tokens.append(token);
+            i++;
+            continue;
+        }
+
+        // Comma (for multi-arg functions in the future)
+        if (c == ',')
+        {
+            Token token;
+            token.type = Token::TOKEN_COMMA;
+            token.value = c;
+            tokens.append(token);
+            i++;
+            continue;
+        }
+
+        errorMessage = QString("Invalid character at position %1: %2").arg(i).arg(c);
+        return QList<Token>();
+    }
+
+    // Add end token marker to simplify parsing logic
+    Token endToken;
+    endToken.type = Token::TOKEN_END;
+    tokens.append(endToken);
+
+    return tokens;
+}
+
+/**
+ * @brief Parse an expression (lowest precedence: addition and subtraction)
+ *
+ * Grammar: expression = term (('+' | '-') term)*
+ *
+ * This handles left-associative binary operators with lowest precedence.
+ * For example: "a + b - c" is parsed as "(a + b) - c"
+ *
+ * @param tokens List of tokens to parse
+ * @param pos Current position in token list (updated as tokens are consumed)
+ * @return Expression tree node representing the parsed expression
+ */
+MathExpressionParser::NodePtr MathExpressionParser::parseExpression(const QList<Token>& tokens, int& pos)
+{
+    NodePtr left = parseTerm(tokens, pos);
+
+    while (pos < tokens.size() &&
+           tokens[pos].type == Token::TOKEN_OPERATOR &&
+           (tokens[pos].value == "+" || tokens[pos].value == "-"))
+    {
+        QString op = tokens[pos].value;
+        pos++;
+
+        NodePtr right = parseTerm(tokens, pos);
+
+        NodePtr node = NodePtr::create();
+        node->type = NODE_OPERATOR;
+        node->operatorType = (op == "+") ? OP_ADD : OP_SUBTRACT;
+        node->left = left;
+        node->right = right;
+
+        left = node;
+    }
+
+    return left;
+}
+
+/**
+ * @brief Parse a term (medium precedence: multiplication and division)
+ *
+ * Grammar: term = power (('*' | '/') power)*
+ *
+ * Handles left-associative operators with higher precedence than +/-.
+ * For example: "a * b / c" is parsed as "(a * b) / c"
+ *
+ * @param tokens List of tokens to parse
+ * @param pos Current position in token list (updated as tokens are consumed)
+ * @return Expression tree node representing the parsed term
+ */
+MathExpressionParser::NodePtr MathExpressionParser::parseTerm(const QList<Token>& tokens, int& pos)
+{
+    NodePtr left = parsePower(tokens, pos);
+
+    while (pos < tokens.size() &&
+           tokens[pos].type == Token::TOKEN_OPERATOR &&
+           (tokens[pos].value == "*" || tokens[pos].value == "/"))
+    {
+        QString op = tokens[pos].value;
+        pos++;
+
+        NodePtr right = parsePower(tokens, pos);
+
+        NodePtr node = NodePtr::create();
+        node->type = NODE_OPERATOR;
+        node->operatorType = (op == "*") ? OP_MULTIPLY : OP_DIVIDE;
+        node->left = left;
+        node->right = right;
+
+        left = node;
+    }
+
+    return left;
+}
+
+/**
+ * @brief Parse power operation (highest precedence: exponentiation)
+ *
+ * Grammar: power = unary ('^' power)?
+ *
+ * Handles RIGHT-associative exponentiation operator.
+ * For example: "2 ^ 3 ^ 2" is parsed as "2 ^ (3 ^ 2)" = 2^9 = 512
+ * (not "(2 ^ 3) ^ 2" = 8^2 = 64)
+ *
+ * @param tokens List of tokens to parse
+ * @param pos Current position in token list (updated as tokens are consumed)
+ * @return Expression tree node representing the power operation
+ */
+MathExpressionParser::NodePtr MathExpressionParser::parsePower(const QList<Token>& tokens, int& pos)
+{
+    NodePtr left = parseUnary(tokens, pos);
+
+    if (pos < tokens.size() &&
+        tokens[pos].type == Token::TOKEN_OPERATOR &&
+        tokens[pos].value == "^")
+    {
+        pos++;
+        NodePtr right = parsePower(tokens, pos);  // Right-associative
+
+        NodePtr node = NodePtr::create();
+        node->type = NODE_OPERATOR;
+        node->operatorType = OP_POWER;
+        node->left = left;
+        node->right = right;
+
+        return node;
+    }
+
+    return left;
+}
+
+// Parse unary: handles unary minus
+MathExpressionParser::NodePtr MathExpressionParser::parseUnary(const QList<Token>& tokens, int& pos)
+{
+    if (pos < tokens.size() &&
+        tokens[pos].type == Token::TOKEN_OPERATOR &&
+        tokens[pos].value == "-")
+    {
+        pos++;
+        NodePtr operand = parseUnary(tokens, pos);
+
+        NodePtr node = NodePtr::create();
+        node->type = NODE_OPERATOR;
+        node->operatorType = OP_NEGATE;
+        node->left = operand;
+
+        return node;
+    }
+
+    return parsePrimary(tokens, pos);
+}
+
+// Parse primary: handles numbers, variables, functions, and parentheses
+MathExpressionParser::NodePtr MathExpressionParser::parsePrimary(const QList<Token>& tokens, int& pos)
+{
+    if (pos >= tokens.size())
+    {
+        throw QString("Unexpected end of expression");
+    }
+
+    Token token = tokens[pos];
+
+    // Number
+    if (token.type == Token::TOKEN_NUMBER)
+    {
+        pos++;
+        NodePtr node = NodePtr::create();
+        node->type = NODE_NUMBER;
+        node->numberValue = token.numberValue;
+        return node;
+    }
+
+    // Variable
+    if (token.type == Token::TOKEN_VARIABLE)
+    {
+        pos++;
+        NodePtr node = NodePtr::create();
+        node->type = NODE_VARIABLE;
+        node->variableName = token.value;
+        return node;
+    }
+
+    // Function
+    if (token.type == Token::TOKEN_FUNCTION)
+    {
+        QString funcName = token.value;
+        pos++;
+
+        // Expect '('
+        if (pos >= tokens.size() || tokens[pos].type != Token::TOKEN_LEFT_PAREN)
+        {
+            throw QString("Expected '(' after function name");
+        }
+        pos++;
+
+        // Parse argument
+        NodePtr argument = parseExpression(tokens, pos);
+
+        // Expect ')'
+        if (pos >= tokens.size() || tokens[pos].type != Token::TOKEN_RIGHT_PAREN)
+        {
+            throw QString("Expected ')' after function argument");
+        }
+        pos++;
+
+        NodePtr node = NodePtr::create();
+        node->type = NODE_FUNCTION;
+        node->argument = argument;
+
+        // Set function type
+        if (funcName == "abs") node->functionType = FUNC_ABS;
+        else if (funcName == "sqrt") node->functionType = FUNC_SQRT;
+        else if (funcName == "log") node->functionType = FUNC_LOG;
+        else if (funcName == "exp") node->functionType = FUNC_EXP;
+        else if (funcName == "sin") node->functionType = FUNC_SIN;
+        else if (funcName == "cos") node->functionType = FUNC_COS;
+        else if (funcName == "tan") node->functionType = FUNC_TAN;
+        else
+        {
+            throw QString("Unknown function: %1").arg(funcName);
+        }
+
+        return node;
+    }
+
+    // Parenthesized expression
+    if (token.type == Token::TOKEN_LEFT_PAREN)
+    {
+        pos++;
+        NodePtr node = parseExpression(tokens, pos);
+
+        if (pos >= tokens.size() || tokens[pos].type != Token::TOKEN_RIGHT_PAREN)
+        {
+            throw QString("Expected ')'");
+        }
+        pos++;
+
+        return node;
+    }
+
+    throw QString("Unexpected token: %1").arg(token.value);
+}
+
+bool MathExpressionParser::evaluate(const QMap<QString, double>& variables, double& result) const
+{
+    if (!rootNode)
+    {
+        return false;
+    }
+
+    return evaluateNode(rootNode, variables, result);
+}
+
+bool MathExpressionParser::evaluateNode(const NodePtr& node, const QMap<QString, double>& variables, double& result) const
+{
+    if (!node)
+    {
+        return false;
+    }
+
+    switch (node->type)
+    {
+    case NODE_NUMBER:
+        result = node->numberValue;
+        return true;
+
+    case NODE_VARIABLE:
+        if (!variables.contains(node->variableName))
+        {
+            return false;
+        }
+        result = variables[node->variableName];
+        return true;
+
+    case NODE_OPERATOR:
+    {
+        double leftVal = 0.0;
+        double rightVal = 0.0;
+
+        if (node->operatorType == OP_NEGATE)
+        {
+            if (!evaluateNode(node->left, variables, leftVal))
+            {
+                return false;
+            }
+            result = -leftVal;
+            return true;
+        }
+
+        if (!evaluateNode(node->left, variables, leftVal) ||
+            !evaluateNode(node->right, variables, rightVal))
+        {
+            return false;
+        }
+
+        switch (node->operatorType)
+        {
+        case OP_ADD:
+            result = leftVal + rightVal;
+            return true;
+
+        case OP_SUBTRACT:
+            result = leftVal - rightVal;
+            return true;
+
+        case OP_MULTIPLY:
+            result = leftVal * rightVal;
+            return true;
+
+        case OP_DIVIDE:
+            if (rightVal == 0.0)
+            {
+                return false;  // Division by zero
+            }
+            result = leftVal / rightVal;
+            return true;
+
+        case OP_POWER:
+            result = pow(leftVal, rightVal);
+            return true;
+
+        default:
+            return false;
+        }
+    }
+
+    case NODE_FUNCTION:
+    {
+        double argVal = 0.0;
+        if (!evaluateNode(node->argument, variables, argVal))
+        {
+            return false;
+        }
+
+        switch (node->functionType)
+        {
+        case FUNC_ABS:
+            result = fabs(argVal);
+            return true;
+
+        case FUNC_SQRT:
+            if (argVal < 0.0)
+            {
+                return false;  // Negative sqrt
+            }
+            result = sqrt(argVal);
+            return true;
+
+        case FUNC_LOG:
+            if (argVal <= 0.0)
+            {
+                return false;  // Log of non-positive
+            }
+            result = log(argVal);
+            return true;
+
+        case FUNC_EXP:
+            result = exp(argVal);
+            return true;
+
+        case FUNC_SIN:
+            result = sin(argVal);
+            return true;
+
+        case FUNC_COS:
+            result = cos(argVal);
+            return true;
+
+        case FUNC_TAN:
+            result = tan(argVal);
+            return true;
+
+        default:
+            return false;
+        }
+    }
+
+    default:
+        return false;
+    }
+}
+
+QStringList MathExpressionParser::getVariables() const
+{
+    QStringList variables;
+    if (rootNode)
+    {
+        collectVariables(rootNode, variables);
+    }
+    return variables;
+}
+
+void MathExpressionParser::collectVariables(const NodePtr& node, QStringList& variables) const
+{
+    if (!node)
+    {
+        return;
+    }
+
+    if (node->type == NODE_VARIABLE)
+    {
+        if (!variables.contains(node->variableName))
+        {
+            variables.append(node->variableName);
+        }
+    }
+
+    collectVariables(node->left, variables);
+    collectVariables(node->right, variables);
+    collectVariables(node->argument, variables);
+}
+
+bool MathExpressionParser::isOperator(QChar c) const
+{
+    return c == '+' || c == '-' || c == '*' || c == '/' || c == '^';
+}

--- a/src/math_expression_parser.hpp
+++ b/src/math_expression_parser.hpp
@@ -1,0 +1,156 @@
+#ifndef MATH_EXPRESSION_PARSER_HPP
+#define MATH_EXPRESSION_PARSER_HPP
+
+#include <QString>
+#include <QMap>
+#include <QSharedPointer>
+#include <cmath>
+
+/**
+ * @brief The MathExpressionParser class parses and evaluates mathematical expressions
+ *
+ * Supports:
+ * - Arithmetic operators: +, -, *, /, ^ (power)
+ * - Functions: abs(), sqrt(), log(), exp(), sin(), cos(), tan()
+ * - Constants: pi, e
+ * - Parentheses for precedence
+ * - Variable substitution
+ *
+ * TODO: Future enhancements:
+ * - Conditional operations (if/then/else)
+ * - Aggregations (moving_avg, min, max over windows)
+ * - Derivatives and integrals
+ */
+class MathExpressionParser
+{
+public:
+    MathExpressionParser();
+    ~MathExpressionParser();
+
+    /**
+     * @brief Parse an expression string into an internal representation
+     * @param expression The mathematical expression (e.g., "a * b + c")
+     * @return true if parsing succeeded, false otherwise
+     */
+    bool parse(const QString& expression);
+
+    /**
+     * @brief Evaluate the parsed expression with given variable values
+     * @param variables Map of variable names to their values
+     * @param result Output parameter for the computed result
+     * @return true if evaluation succeeded, false otherwise
+     */
+    bool evaluate(const QMap<QString, double>& variables, double& result) const;
+
+    /**
+     * @brief Get the last error message
+     * @return Error message string, or empty if no error
+     */
+    QString getError() const { return errorMessage; }
+
+    /**
+     * @brief Get list of variables used in the expression
+     * @return List of variable names
+     */
+    QStringList getVariables() const;
+
+private:
+    // Internal expression node types
+    enum NodeType
+    {
+        NODE_NUMBER,
+        NODE_VARIABLE,
+        NODE_OPERATOR,
+        NODE_FUNCTION
+    };
+
+    enum OperatorType
+    {
+        OP_ADD,
+        OP_SUBTRACT,
+        OP_MULTIPLY,
+        OP_DIVIDE,
+        OP_POWER,
+        OP_NEGATE  // Unary minus
+    };
+
+    enum FunctionType
+    {
+        FUNC_ABS,
+        FUNC_SQRT,
+        FUNC_LOG,
+        FUNC_EXP,
+        FUNC_SIN,
+        FUNC_COS,
+        FUNC_TAN
+    };
+
+    // Expression tree node
+    struct ExpressionNode
+    {
+        NodeType type;
+
+        // Value for NUMBER nodes
+        double numberValue = 0.0;
+
+        // Variable name for VARIABLE nodes
+        QString variableName;
+
+        // Operator type for OPERATOR nodes
+        OperatorType operatorType;
+
+        // Function type for FUNCTION nodes
+        FunctionType functionType;
+
+        // Child nodes
+        QSharedPointer<ExpressionNode> left;
+        QSharedPointer<ExpressionNode> right;
+        QSharedPointer<ExpressionNode> argument;  // For functions
+    };
+
+    typedef QSharedPointer<ExpressionNode> NodePtr;
+
+    // Tokenizer
+    struct Token
+    {
+        enum Type
+        {
+            TOKEN_NUMBER,
+            TOKEN_VARIABLE,
+            TOKEN_OPERATOR,
+            TOKEN_FUNCTION,
+            TOKEN_LEFT_PAREN,
+            TOKEN_RIGHT_PAREN,
+            TOKEN_COMMA,
+            TOKEN_END
+        };
+
+        Type type;
+        QString value;
+        double numberValue = 0.0;
+    };
+
+    // Parsing methods
+    QList<Token> tokenize(const QString& expression);
+    NodePtr parseExpression(const QList<Token>& tokens, int& pos);
+    NodePtr parseTerm(const QList<Token>& tokens, int& pos);
+    NodePtr parseFactor(const QList<Token>& tokens, int& pos);
+    NodePtr parsePower(const QList<Token>& tokens, int& pos);
+    NodePtr parseUnary(const QList<Token>& tokens, int& pos);
+    NodePtr parsePrimary(const QList<Token>& tokens, int& pos);
+
+    // Evaluation method
+    bool evaluateNode(const NodePtr& node, const QMap<QString, double>& variables, double& result) const;
+
+    // Helper methods
+    void collectVariables(const NodePtr& node, QStringList& variables) const;
+    bool isOperator(QChar c) const;
+
+    // Parsed expression tree
+    NodePtr rootNode;
+
+    // Error handling
+    QString errorMessage;
+};
+
+#endif // MATH_EXPRESSION_PARSER_HPP

--- a/src/math_trace_computer.cpp
+++ b/src/math_trace_computer.cpp
@@ -1,0 +1,311 @@
+#include "math_trace_computer.hpp"
+#include <QElapsedTimer>
+#include <QDebug>
+#include <algorithm>
+#include <set>
+
+MathTraceComputer::MathTraceComputer()
+    : cancelRequested(false)
+{
+}
+
+MathTraceComputer::~MathTraceComputer()
+{
+}
+
+/**
+ * @brief Set up computation parameters (call from main thread before starting worker thread)
+ *
+ * @param expression Mathematical expression to evaluate
+ * @param variableMapping Map of variable names to input data series
+ * @param outputSeries Series to populate with computed results
+ * @param maxGapSize Maximum gap in milliseconds to interpolate across (default: 1000ms)
+ */
+void MathTraceComputer::compute(const QString& expression,
+                                const QMap<QString, DataSeriesPointer>& variableMapping,
+                                MathDataSeriesPointer outputSeries,
+                                double maxGapSize)
+{
+    QMutexLocker locker(&computeMutex);
+
+    currentExpression = expression;
+    currentVariableMapping = variableMapping;
+    currentOutputSeries = outputSeries;
+    currentMaxGapSize = maxGapSize;
+    cancelRequested = false;
+}
+
+/**
+ * @brief Execute the math trace computation (runs in background thread)
+ *
+ * Algorithm:
+ * 1. Parse and validate expression
+ * 2. Collect all unique timestamps from input series (creates timestamp union)
+ * 3. For each timestamp:
+ *    - Check if it's in a valid region (not in large gap)
+ *    - Interpolate values from all input series at that timestamp
+ *    - Evaluate expression with interpolated values
+ *    - Add result to output series (if valid)
+ * 4. Emit progress updates periodically
+ *
+ * This creates a new series with timestamps from ALL input series combined,
+ * preserving maximum data fidelity.
+ */
+void MathTraceComputer::startComputation()
+{
+    QElapsedTimer timer;
+    timer.start();
+
+    emit computationStarted();
+
+    // Parse the expression
+    MathExpressionParser parser;
+    if (!parser.parse(currentExpression))
+    {
+        emit computationFailed(QString("Failed to parse expression: %1").arg(parser.getError()));
+        return;
+    }
+
+    // Verify all required variables are provided
+    QStringList requiredVars = parser.getVariables();
+    for (const QString& var : requiredVars)
+    {
+        if (!currentVariableMapping.contains(var))
+        {
+            emit computationFailed(QString("Variable '%1' not found in mapping").arg(var));
+            return;
+        }
+    }
+
+    // Check if any input series is empty
+    for (const QString& var : requiredVars)
+    {
+        if (currentVariableMapping[var]->size() == 0)
+        {
+            emit computationFailed(QString("Input series for variable '%1' is empty").arg(var));
+            return;
+        }
+    }
+
+    // Collect all unique timestamps from input series
+    qDebug() << "Collecting timestamps from input series...";
+    QVector<double> timestamps = collectTimestamps(currentVariableMapping);
+
+    if (timestamps.isEmpty())
+    {
+        emit computationFailed("No timestamps found in input series");
+        return;
+    }
+
+    qDebug() << "Found" << timestamps.size() << "unique timestamps";
+
+    // Clear existing data in output series
+    currentOutputSeries->clearData(false);
+
+    // Main computation loop: evaluate expression at each timestamp
+    int lastProgress = -1;
+    int validPoints = 0;
+    int skippedPoints = 0;
+
+    for (int i = 0; i < timestamps.size(); ++i)
+    {
+        // Check for cancellation request from user
+        if (cancelRequested)
+        {
+            emit computationFailed("Computation cancelled");
+            return;
+        }
+
+        double timestamp = timestamps[i];
+
+        // Skip timestamps in large gaps (prevents wild interpolation across disconnected regions)
+        if (!isTimestampValid(timestamp, currentVariableMapping, currentMaxGapSize))
+        {
+            skippedPoints++;
+            continue;
+        }
+
+        // Interpolate values for each variable at this timestamp using linear interpolation
+        QMap<QString, double> variableValues;
+        bool allValid = true;
+
+        for (const QString& var : requiredVars)
+        {
+            DataSeriesPointer series = currentVariableMapping[var];
+            double value = series->getValueAtTime(timestamp, DataSeries::INTERPOLATE);
+
+            // Check for NaN or Inf (can occur at boundaries or with invalid data)
+            if (std::isnan(value) || std::isinf(value))
+            {
+                allValid = false;
+                break;
+            }
+
+            variableValues[var] = value;
+        }
+
+        if (!allValid)
+        {
+            skippedPoints++;
+            continue;
+        }
+
+        // Evaluate the expression
+        double result = 0.0;
+        if (!parser.evaluate(variableValues, result))
+        {
+            skippedPoints++;
+            continue;
+        }
+
+        // Check if result is valid
+        if (std::isnan(result) || std::isinf(result))
+        {
+            skippedPoints++;
+            continue;
+        }
+
+        // Add computed point to output series
+        currentOutputSeries->addData(timestamp, result, false);
+        validPoints++;
+
+        // Report progress periodically (every 10%)
+        int progress = (i * 100) / timestamps.size();
+        if (progress != lastProgress && progress % 10 == 0)
+        {
+            emit progressUpdated(progress);
+            lastProgress = progress;
+        }
+    }
+
+    // Trigger data update on the output series
+    currentOutputSeries->update();
+
+    qDebug() << "Math trace computation complete:";
+    qDebug() << "  - Time elapsed:" << timer.elapsed() << "ms";
+    qDebug() << "  - Valid points:" << validPoints;
+    qDebug() << "  - Skipped points:" << skippedPoints;
+    qDebug() << "  - Total timestamps:" << timestamps.size();
+
+    emit progressUpdated(100);
+    emit computationComplete();
+}
+
+void MathTraceComputer::cancelComputation()
+{
+    QMutexLocker locker(&computeMutex);
+    cancelRequested = true;
+}
+
+/**
+ * @brief Collect all unique timestamps from all input series
+ *
+ * Creates the timestamp union - the set of all timestamps that appear in ANY input series.
+ * This ensures we preserve all data points from all inputs.
+ *
+ * Example:
+ *   Series A timestamps: [0, 10, 20]
+ *   Series B timestamps: [5, 15, 25]
+ *   Result: [0, 5, 10, 15, 20, 25]  (sorted, unique)
+ *
+ * @param series Map of input series
+ * @return Sorted vector of all unique timestamps (in milliseconds)
+ */
+QVector<double> MathTraceComputer::collectTimestamps(const QMap<QString, DataSeriesPointer>& series)
+{
+    // Use std::set for automatic sorting and deduplication (O(log n) insert)
+    std::set<double> timestampSet;
+
+    // Collect all timestamps from all input series
+    for (auto it = series.begin(); it != series.end(); ++it)
+    {
+        DataSeriesPointer s = it.value();
+
+        for (uint64_t i = 0; i < s->size(); ++i)
+        {
+            double timestamp = s->getTimestamp(i);
+            timestampSet.insert(timestamp);  // Duplicates automatically ignored
+        }
+    }
+
+    // Convert set to vector (already sorted by std::set)
+    QVector<double> timestamps;
+    timestamps.reserve(timestampSet.size());
+
+    for (double timestamp : timestampSet)
+    {
+        timestamps.append(timestamp);
+    }
+
+    return timestamps;
+}
+
+/**
+ * @brief Check if a timestamp is valid for computation (not in a large gap)
+ *
+ * This prevents wildly inaccurate interpolation across disconnected data regions.
+ *
+ * A timestamp is considered INVALID if it falls in a gap larger than maxGapSize
+ * in ANY input series. This ensures we only compute where we have reasonable
+ * data coverage.
+ *
+ * Example (maxGapSize = 1000ms):
+ *   Series A: [0ms, 10ms, 2000ms, 2010ms]  (gap of 1990ms between 10 and 2000)
+ *   Timestamp 1000ms: INVALID (in the large gap)
+ *   Timestamp 5ms: VALID (between 0 and 10, gap only 10ms)
+ *   Timestamp 2005ms: VALID (between 2000 and 2010, gap only 10ms)
+ *
+ * @param timestamp The timestamp to check (milliseconds)
+ * @param series Map of input series to check
+ * @param maxGapSize Maximum acceptable gap size (milliseconds)
+ * @return true if timestamp is valid for computation, false if in large gap
+ */
+bool MathTraceComputer::isTimestampValid(double timestamp,
+                                        const QMap<QString, DataSeriesPointer>& series,
+                                        double maxGapSize)
+{
+    // Check each input series - timestamp must be valid in ALL series
+    for (auto it = series.begin(); it != series.end(); ++it)
+    {
+        DataSeriesPointer s = it.value();
+
+        // Find the index where this timestamp would be inserted (binary search)
+        uint64_t idx = s->getIndexForTimestamp(timestamp);
+
+        // Handle boundary cases (before first point or after last point)
+        if (idx == 0 || idx >= s->size())
+        {
+            // Check distance to nearest actual data point
+            if (idx == 0 && s->size() > 0)
+            {
+                double nearestTime = s->getTimestamp(0);
+                if (fabs(timestamp - nearestTime) > maxGapSize)
+                {
+                    return false;
+                }
+            }
+            else if (idx >= s->size() && s->size() > 0)
+            {
+                double nearestTime = s->getTimestamp(s->size() - 1);
+                if (fabs(timestamp - nearestTime) > maxGapSize)
+                {
+                    return false;
+                }
+            }
+        }
+        else
+        {
+            // Check gap size around this timestamp
+            double timeBefore = s->getTimestamp(idx - 1);
+            double timeAfter = s->getTimestamp(idx);
+            double gapSize = timeAfter - timeBefore;
+
+            if (gapSize > maxGapSize)
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}

--- a/src/math_trace_computer.cpp
+++ b/src/math_trace_computer.cpp
@@ -181,6 +181,12 @@ void MathTraceComputer::startComputation()
     // Trigger data update on the output series
     currentOutputSeries->update();
 
+    if (validPoints == 0)
+    {
+        emit computationFailed(QString("Expression produced no valid results (%1 points skipped) - check for division by zero or invalid operations").arg(skippedPoints));
+        return;
+    }
+
     qDebug() << "Math trace computation complete:";
     qDebug() << "  - Time elapsed:" << timer.elapsed() << "ms";
     qDebug() << "  - Valid points:" << validPoints;

--- a/src/math_trace_computer.hpp
+++ b/src/math_trace_computer.hpp
@@ -1,0 +1,103 @@
+#ifndef MATH_TRACE_COMPUTER_HPP
+#define MATH_TRACE_COMPUTER_HPP
+
+#include <QObject>
+#include <QThread>
+#include <QMutex>
+#include "data_series.hpp"
+#include "math_data_series.hpp"
+#include "math_expression_parser.hpp"
+
+/**
+ * @brief The MathTraceComputer class performs background computation of math traces
+ *
+ * This class runs in a background thread and:
+ * 1. Merges timestamps from all input series
+ * 2. Interpolates values at each timestamp
+ * 3. Evaluates the mathematical expression
+ * 4. Populates the output MathDataSeries with computed points
+ *
+ * Large gaps in data are handled by not interpolating across them.
+ */
+class MathTraceComputer : public QObject
+{
+    Q_OBJECT
+
+public:
+    MathTraceComputer();
+    virtual ~MathTraceComputer();
+
+    /**
+     * @brief Compute a math trace from input series and expression
+     * @param expression Mathematical expression to evaluate
+     * @param variableMapping Map of variable names to input series
+     * @param outputSeries The series to populate with computed results
+     * @param maxGapSize Maximum gap (in ms) to interpolate across. Larger gaps are left empty.
+     */
+    void compute(const QString& expression,
+                 const QMap<QString, DataSeriesPointer>& variableMapping,
+                 MathDataSeriesPointer outputSeries,
+                 double maxGapSize = 1000.0);  // Default: 1 second
+
+signals:
+    /**
+     * @brief Emitted when computation starts
+     */
+    void computationStarted();
+
+    /**
+     * @brief Emitted periodically during computation to report progress
+     * @param progress Progress percentage (0-100)
+     */
+    void progressUpdated(int progress);
+
+    /**
+     * @brief Emitted when computation completes successfully
+     */
+    void computationComplete();
+
+    /**
+     * @brief Emitted when computation fails
+     * @param error Error message
+     */
+    void computationFailed(QString error);
+
+public slots:
+    /**
+     * @brief Start the computation (call this from the worker thread)
+     */
+    void startComputation();
+
+    /**
+     * @brief Cancel ongoing computation
+     */
+    void cancelComputation();
+
+private:
+    /**
+     * @brief Collect all unique timestamps from input series
+     * @return Sorted list of timestamps
+     */
+    QVector<double> collectTimestamps(const QMap<QString, DataSeriesPointer>& series);
+
+    /**
+     * @brief Check if a timestamp should be skipped due to large gaps
+     * @param timestamp Current timestamp
+     * @param series Input series to check
+     * @param maxGapSize Maximum allowed gap
+     * @return true if timestamp is within valid data regions
+     */
+    bool isTimestampValid(double timestamp,
+                         const QMap<QString, DataSeriesPointer>& series,
+                         double maxGapSize);
+
+    QString currentExpression;
+    QMap<QString, DataSeriesPointer> currentVariableMapping;
+    MathDataSeriesPointer currentOutputSeries;
+    double currentMaxGapSize;
+
+    QMutex computeMutex;
+    bool cancelRequested;
+};
+
+#endif // MATH_TRACE_COMPUTER_HPP

--- a/src/plot_widget.cpp
+++ b/src/plot_widget.cpp
@@ -169,6 +169,8 @@ double PlotWidget::getNewestTimestamp(bool *ok) const
 
         if (series.isNull()) continue;
 
+        if (!series->hasData()) continue;
+
         t = series->getNewestTimestamp();
 
         if (t > newest)
@@ -215,6 +217,8 @@ double PlotWidget::getMinimumValue(bool *ok) const
 
         if (series.isNull()) continue;
 
+        if (!series->hasData()) continue;
+
         value = series->getMinimumValue();
 
         if (value < minimum)
@@ -260,6 +264,8 @@ double PlotWidget::getMaximumValue(bool *ok) const
         auto series = curve->getDataSeries();
 
         if (series.isNull()) continue;
+
+        if (!series->hasData()) continue;
 
         value = series->getMaximumValue();
 

--- a/src/widgets/math_trace_dialog.cpp
+++ b/src/widgets/math_trace_dialog.cpp
@@ -1,0 +1,486 @@
+#include "math_trace_dialog.hpp"
+#include "ui_math_trace_dialog.h"
+#include "data_source_manager.hpp"
+#include "math_data_source.hpp"
+#include "math_expression_parser.hpp"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QDebug>
+
+//=============================================================================
+// VariableRow Implementation
+//=============================================================================
+// Represents a single row in the variable mapping UI:
+// [var_name] = [Series Dropdown] [-]
+//
+
+VariableRow::VariableRow(QWidget* parent)
+    : QWidget(parent)
+{
+    QHBoxLayout* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    editVariableName = new QLineEdit(this);
+    editVariableName->setPlaceholderText("Variable name (e.g., rpm1)");
+    editVariableName->setMaximumWidth(150);
+
+    QLabel* labelEquals = new QLabel("=", this);
+
+    comboSeries = new QComboBox(this);
+    comboSeries->setMinimumWidth(300);
+
+    btnDelete = new QPushButton("-", this);
+    btnDelete->setMaximumWidth(30);
+    btnDelete->setToolTip("Remove this variable");
+
+    layout->addWidget(editVariableName);
+    layout->addWidget(labelEquals);
+    layout->addWidget(comboSeries);
+    layout->addWidget(btnDelete);
+    layout->addStretch();
+
+    connect(btnDelete, &QPushButton::clicked, this, &VariableRow::onDeleteClicked);
+
+    populateSeriesComboBox();
+}
+
+VariableRow::~VariableRow()
+{
+}
+
+QString VariableRow::getVariableName() const
+{
+    return editVariableName->text().trimmed();
+}
+
+void VariableRow::setVariableName(const QString& name)
+{
+    editVariableName->setText(name);
+}
+
+DataSeriesPointer VariableRow::getSelectedSeries() const
+{
+    int index = comboSeries->currentIndex();
+    if (index < 0 || !seriesMap.contains(index))
+    {
+        return DataSeriesPointer();
+    }
+
+    return seriesMap[index];
+}
+
+void VariableRow::setSelectedSeries(const QString& sourceLabel, const QString& seriesLabel)
+{
+    QString combinedLabel = sourceLabel + " - " + seriesLabel;
+
+    for (int i = 0; i < comboSeries->count(); ++i)
+    {
+        if (comboSeries->itemText(i) == combinedLabel)
+        {
+            comboSeries->setCurrentIndex(i);
+            return;
+        }
+    }
+}
+
+/**
+ * @brief Populate the series dropdown with all available data series
+ *
+ * Format: "SourceName - SeriesLabel" (e.g., "CSV File - Voltage", "Telemetry - RPM")
+ * Only includes series that have data (non-empty).
+ */
+void VariableRow::populateSeriesComboBox()
+{
+    comboSeries->clear();
+    seriesMap.clear();
+
+    DataSourceManager* manager = DataSourceManager::getInstance();
+    int itemIndex = 0;
+
+    // Iterate through all data sources
+    for (int i = 0; i < manager->getSourceCount(); ++i)
+    {
+        DataSourcePointer source = manager->getSourceByIndex(i);
+        if (!source)
+        {
+            continue;
+        }
+
+        QStringList seriesLabels = source->getSeriesLabels();
+
+        // Add each series from this source
+        for (const QString& seriesLabel : seriesLabels)
+        {
+            DataSeriesPointer series = source->getSeriesByLabel(seriesLabel);
+            if (series && series->hasData())  // Only non-empty series
+            {
+                QString displayText = source->getLabel() + " - " + seriesLabel;
+                comboSeries->addItem(displayText);
+                seriesMap[itemIndex] = series;  // Store pointer for retrieval
+                itemIndex++;
+            }
+        }
+    }
+}
+
+void VariableRow::onDeleteClicked()
+{
+    emit deleteRequested(this);
+}
+
+//=============================================================================
+// MathTraceDialog Implementation
+//=============================================================================
+// Main dialog for creating and editing math traces
+//
+// User workflow:
+// 1. Define variables (short names like "V", "I")
+// 2. Map each variable to a data series from dropdowns
+// 3. Enter mathematical expression (e.g., "V * I")
+// 4. Name the output trace (e.g., "Power")
+// 5. Click OK → Validation → Background computation → Done
+//
+// Validation ensures:
+// - All variable names are unique and non-empty
+// - All variables are mapped to series
+// - Expression is syntactically valid
+// - All expression variables have definitions
+// - Trace name is unique
+//
+
+MathTraceDialog::MathTraceDialog(QWidget *parent)
+    : QDialog(parent),
+      ui(new Ui::MathTraceDialog),
+      computeThread(nullptr),
+      computer(nullptr),
+      isEditMode(false)
+{
+    ui->setupUi(this);
+
+    connect(ui->btnAddVariable, &QPushButton::clicked, this, &MathTraceDialog::onAddVariableClicked);
+    connect(ui->editExpression, &QLineEdit::textChanged, this, &MathTraceDialog::onExpressionChanged);
+
+    // Add initial variable row
+    onAddVariableClicked();
+
+    // Set window modality
+    setModal(true);
+}
+
+MathTraceDialog::~MathTraceDialog()
+{
+    // Clean up computation thread
+    if (computeThread)
+    {
+        if (computer)
+        {
+            computer->cancelComputation();
+        }
+
+        computeThread->quit();
+        computeThread->wait();
+
+        delete computer;
+        delete computeThread;
+    }
+
+    delete ui;
+}
+
+void MathTraceDialog::setEditMode(MathDataSeriesPointer series)
+{
+    if (!series)
+    {
+        return;
+    }
+
+    isEditMode = true;
+    editingSeries = series;
+
+    setWindowTitle("Edit Math Trace");
+
+    // Populate fields from existing series
+    ui->editTraceName->setText(series->getLabel());
+    ui->editExpression->setText(series->getExpression());
+
+    // Clear existing variable rows
+    while (!variableRows.isEmpty())
+    {
+        VariableRow* row = variableRows.takeFirst();
+        ui->variablesLayout->removeWidget(row);
+        row->deleteLater();
+    }
+
+    // Add variable rows from existing mapping
+    QMap<QString, DataSeriesPointer> mapping = series->getVariableMapping();
+    for (auto it = mapping.begin(); it != mapping.end(); ++it)
+    {
+        QString varName = it.key();
+        DataSeriesPointer inputSeries = it.value();
+
+        VariableRow* row = new VariableRow(this);
+        row->setVariableName(varName);
+
+        // Find the source for this series
+        DataSourceManager* manager = DataSourceManager::getInstance();
+        for (int i = 0; i < manager->getSourceCount(); ++i)
+        {
+            DataSourcePointer source = manager->getSourceByIndex(i);
+            if (source)
+            {
+                DataSeriesPointer foundSeries = source->getSeriesByLabel(inputSeries->getLabel());
+                if (foundSeries == inputSeries)
+                {
+                    row->setSelectedSeries(source->getLabel(), inputSeries->getLabel());
+                    break;
+                }
+            }
+        }
+
+        connect(row, &VariableRow::deleteRequested, this, &MathTraceDialog::onDeleteVariable);
+
+        variableRows.append(row);
+        ui->variablesLayout->addWidget(row);
+    }
+}
+
+void MathTraceDialog::onAddVariableClicked()
+{
+    VariableRow* row = new VariableRow(this);
+    connect(row, &VariableRow::deleteRequested, this, &MathTraceDialog::onDeleteVariable);
+
+    variableRows.append(row);
+    ui->variablesLayout->addWidget(row);
+}
+
+void MathTraceDialog::onDeleteVariable(VariableRow* row)
+{
+    // Don't allow deleting if only one row remains
+    if (variableRows.size() <= 1)
+    {
+        QMessageBox::warning(this, "Cannot Delete", "At least one variable must be defined.");
+        return;
+    }
+
+    variableRows.removeOne(row);
+    ui->variablesLayout->removeWidget(row);
+    row->deleteLater();
+}
+
+void MathTraceDialog::onExpressionChanged()
+{
+    setStatus("");
+}
+
+bool MathTraceDialog::validateInputs()
+{
+    // Check trace name
+    QString traceName = ui->editTraceName->text().trimmed();
+    if (traceName.isEmpty())
+    {
+        setStatus("Error: Trace name cannot be empty", true);
+        return false;
+    }
+
+    // Check if name already exists (unless in edit mode with same name)
+    MathDataSource* mathSource = MathDataSource::getInstance();
+    if (mathSource->hasMathSeries(traceName))
+    {
+        if (!isEditMode || editingSeries->getLabel() != traceName)
+        {
+            setStatus("Error: A math trace with this name already exists", true);
+            return false;
+        }
+    }
+
+    // Check expression
+    QString expression = ui->editExpression->text().trimmed();
+    if (expression.isEmpty())
+    {
+        setStatus("Error: Expression cannot be empty", true);
+        return false;
+    }
+
+    // Parse expression to check validity
+    MathExpressionParser parser;
+    if (!parser.parse(expression))
+    {
+        setStatus(QString("Error: %1").arg(parser.getError()), true);
+        return false;
+    }
+
+    // Check variables
+    if (variableRows.isEmpty())
+    {
+        setStatus("Error: At least one variable must be defined", true);
+        return false;
+    }
+
+    // Build variable mapping
+    QMap<QString, DataSeriesPointer> variableMapping;
+    QSet<QString> usedNames;
+
+    for (VariableRow* row : variableRows)
+    {
+        QString varName = row->getVariableName();
+
+        if (varName.isEmpty())
+        {
+            setStatus("Error: Variable name cannot be empty", true);
+            return false;
+        }
+
+        // Check for duplicate variable names
+        if (usedNames.contains(varName))
+        {
+            setStatus(QString("Error: Duplicate variable name '%1'").arg(varName), true);
+            return false;
+        }
+
+        usedNames.insert(varName);
+
+        DataSeriesPointer series = row->getSelectedSeries();
+        if (!series)
+        {
+            setStatus(QString("Error: No series selected for variable '%1'").arg(varName), true);
+            return false;
+        }
+
+        variableMapping[varName] = series;
+    }
+
+    // Check if all expression variables are defined
+    QStringList expressionVars = parser.getVariables();
+    for (const QString& var : expressionVars)
+    {
+        if (!variableMapping.contains(var))
+        {
+            setStatus(QString("Error: Variable '%1' used in expression but not defined").arg(var), true);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void MathTraceDialog::accept()
+{
+    if (!validateInputs())
+    {
+        return;
+    }
+
+    createMathTrace();
+}
+
+void MathTraceDialog::createMathTrace()
+{
+    QString traceName = ui->editTraceName->text().trimmed();
+    QString expression = ui->editExpression->text().trimmed();
+
+    // Build variable mapping
+    QMap<QString, DataSeriesPointer> variableMapping;
+    for (VariableRow* row : variableRows)
+    {
+        variableMapping[row->getVariableName()] = row->getSelectedSeries();
+    }
+
+    // If in edit mode, remove the old series
+    MathDataSource* mathSource = MathDataSource::getInstance();
+    if (isEditMode && editingSeries)
+    {
+        mathSource->removeMathSeries(editingSeries->getLabel());
+    }
+
+    // Create new MathDataSeries
+    MathDataSeriesPointer mathSeries = MathDataSeriesPointer::create(
+        traceName,
+        expression,
+        variableMapping
+    );
+
+    // Add to MathDataSource
+    mathSource->addMathSeries(mathSeries);
+
+    // Set up computation thread
+    computeThread = new QThread(this);
+    computer = new MathTraceComputer();
+    computer->moveToThread(computeThread);
+
+    connect(computer, &MathTraceComputer::computationStarted, this, &MathTraceDialog::onComputationStarted);
+    connect(computer, &MathTraceComputer::progressUpdated, this, &MathTraceDialog::onProgressUpdated);
+    connect(computer, &MathTraceComputer::computationComplete, this, &MathTraceDialog::onComputationComplete);
+    connect(computer, &MathTraceComputer::computationFailed, this, &MathTraceDialog::onComputationFailed);
+
+    connect(computeThread, &QThread::started, computer, &MathTraceComputer::startComputation);
+
+    // Prepare computation
+    computer->compute(expression, variableMapping, mathSeries);
+
+    // Disable OK button during computation
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+
+    // Start computation
+    computeThread->start();
+}
+
+void MathTraceDialog::onComputationStarted()
+{
+    setStatus("Computing math trace...");
+    ui->progressBar->setVisible(true);
+    ui->progressBar->setValue(0);
+}
+
+void MathTraceDialog::onProgressUpdated(int progress)
+{
+    ui->progressBar->setValue(progress);
+}
+
+void MathTraceDialog::onComputationComplete()
+{
+    ui->progressBar->setVisible(false);
+    setStatus("Math trace created successfully!");
+
+    // Clean up thread
+    if (computeThread)
+    {
+        computeThread->quit();
+        computeThread->wait();
+    }
+
+    // Close dialog
+    QDialog::accept();
+}
+
+void MathTraceDialog::onComputationFailed(QString error)
+{
+    ui->progressBar->setVisible(false);
+    setStatus(QString("Computation failed: %1").arg(error), true);
+
+    // Re-enable OK button
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
+
+    // Clean up thread
+    if (computeThread)
+    {
+        computeThread->quit();
+        computeThread->wait();
+    }
+}
+
+void MathTraceDialog::setStatus(const QString& message, bool isError)
+{
+    ui->labelStatus->setText(message);
+
+    if (isError)
+    {
+        ui->labelStatus->setStyleSheet("QLabel { color: red; }");
+    }
+    else
+    {
+        ui->labelStatus->setStyleSheet("QLabel { color: green; }");
+    }
+}

--- a/src/widgets/math_trace_dialog.cpp
+++ b/src/widgets/math_trace_dialog.cpp
@@ -404,6 +404,7 @@ void MathTraceDialog::createMathTrace()
 
     // Add to MathDataSource
     mathSource->addMathSeries(mathSeries);
+    currentSeries = mathSeries;
 
     // Set up computation thread
     computeThread = new QThread(this);
@@ -459,6 +460,13 @@ void MathTraceDialog::onComputationFailed(QString error)
 {
     ui->progressBar->setVisible(false);
     setStatus(QString("Computation failed: %1").arg(error), true);
+
+    // Remove the series that was added before computation started
+    if (currentSeries)
+    {
+        MathDataSource::getInstance()->removeMathSeries(currentSeries->getLabel());
+        currentSeries.reset();
+    }
 
     // Re-enable OK button
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);

--- a/src/widgets/math_trace_dialog.hpp
+++ b/src/widgets/math_trace_dialog.hpp
@@ -1,0 +1,101 @@
+#ifndef MATH_TRACE_DIALOG_HPP
+#define MATH_TRACE_DIALOG_HPP
+
+#include <QDialog>
+#include <QLineEdit>
+#include <QComboBox>
+#include <QPushButton>
+#include <QThread>
+#include <QMap>
+
+#include "data_series.hpp"
+#include "math_data_series.hpp"
+#include "math_trace_computer.hpp"
+
+namespace Ui {
+class MathTraceDialog;
+}
+
+/**
+ * @brief Widget for a single variable row (variable name + series selector + delete button)
+ */
+class VariableRow : public QWidget
+{
+    Q_OBJECT
+
+public:
+    VariableRow(QWidget* parent = nullptr);
+    ~VariableRow();
+
+    QString getVariableName() const;
+    void setVariableName(const QString& name);
+
+    DataSeriesPointer getSelectedSeries() const;
+    void setSelectedSeries(const QString& sourceLabel, const QString& seriesLabel);
+
+    void populateSeriesComboBox();
+
+signals:
+    void deleteRequested(VariableRow* row);
+
+private slots:
+    void onDeleteClicked();
+
+private:
+    QLineEdit* editVariableName;
+    QComboBox* comboSeries;
+    QPushButton* btnDelete;
+
+    // Store series pointers for combo box items
+    QMap<int, DataSeriesPointer> seriesMap;
+};
+
+/**
+ * @brief The MathTraceDialog class provides UI for creating math traces
+ */
+class MathTraceDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit MathTraceDialog(QWidget *parent = nullptr);
+    ~MathTraceDialog();
+
+    /**
+     * @brief Set the dialog to edit an existing math trace
+     * @param series The existing MathDataSeries to edit
+     */
+    void setEditMode(MathDataSeriesPointer series);
+
+protected:
+    void accept() override;
+
+private slots:
+    void onAddVariableClicked();
+    void onDeleteVariable(VariableRow* row);
+    void onExpressionChanged();
+
+    void onComputationStarted();
+    void onProgressUpdated(int progress);
+    void onComputationComplete();
+    void onComputationFailed(QString error);
+
+private:
+    bool validateInputs();
+    void createMathTrace();
+    void setStatus(const QString& message, bool isError = false);
+
+    Ui::MathTraceDialog *ui;
+
+    QList<VariableRow*> variableRows;
+
+    // Background computation
+    QThread* computeThread;
+    MathTraceComputer* computer;
+
+    // Edit mode
+    bool isEditMode;
+    MathDataSeriesPointer editingSeries;
+};
+
+#endif // MATH_TRACE_DIALOG_HPP

--- a/src/widgets/math_trace_dialog.hpp
+++ b/src/widgets/math_trace_dialog.hpp
@@ -96,6 +96,9 @@ private:
     // Edit mode
     bool isEditMode;
     MathDataSeriesPointer editingSeries;
+
+    // Series currently being computed (so it can be removed on failure)
+    MathDataSeriesPointer currentSeries;
 };
 
 #endif // MATH_TRACE_DIALOG_HPP

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -61,6 +61,7 @@
     </property>
     <addaction name="action_Add_Graph"/>
     <addaction name="separator"/>
+    <addaction name="action_Math_Trace"/>
    </widget>
    <addaction name="menu_File"/>
    <addaction name="menu_View"/>
@@ -121,6 +122,11 @@
   <action name="action_Plugins">
    <property name="text">
     <string>&amp;Plugins</string>
+   </property>
+  </action>
+  <action name="action_Math_Trace">
+   <property name="text">
+    <string>&amp;Math Trace</string>
    </property>
   </action>
  </widget>

--- a/ui/math_trace_dialog.ui
+++ b/ui/math_trace_dialog.ui
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MathTraceDialog</class>
+ <widget class="QDialog" name="MathTraceDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Create Math Trace</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="labelTitle">
+     <property name="text">
+      <string>Define variables by mapping them to data series:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>576</width>
+        <height>200</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="scrollLayout">
+       <item>
+        <layout class="QVBoxLayout" name="variablesLayout">
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="btnAddVariable">
+       <property name="text">
+        <string>+ Add Variable</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="expressionLayout">
+     <item>
+      <widget class="QLineEdit" name="editExpression">
+       <property name="placeholderText">
+        <string>Type equation here (e.g., rpm1-rpm2)</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelEquals">
+       <property name="text">
+        <string>=</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="editTraceName">
+       <property name="placeholderText">
+        <string>Type trace name here</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="labelStatus">
+     <property name="text">
+      <string></string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="value">
+      <number>0</number>
+     </property>
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>MathTraceDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>354</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>MathTraceDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>360</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
> ⚠️ NOTE: Feature created using Claude Code.


## Description

Implements math traces feature that allows users to create computed traces from mathematical expressions applied to existing data series.


Closes #10 Maths channels


## Features

- Arithmetic operators: `+`, `-`, `*`, `/`, `^`
- Functions: `abs()`, `sqrt()`, `log()`, `exp()`, `sin()`, `cos()`, `tan()`
- Constants: `pi`, `e`
- Parentheses for precedence
- Variable substitution


## Workflow

1. Load two data series (e.g., voltage and current)
2. Open Graph → Math Trace
3. Add two variables:
   - `V` = [Select voltage series]
   - `I` = [Select current series]
4. Enter expression: `V * I`
5. Enter trace name: `Power`
6. Click OK
7. Wait for computation (progress bar shown)
8. New trace "Power" appears in "Math Traces" data source
9. Drag onto plot to visualize

## Screenshots
<img width="206" height="108" alt="2026-02-06_15h41_06" src="https://github.com/user-attachments/assets/e220f086-c945-41ea-b583-26c33af93776" />
<br><br>
<img width="602" height="380" alt="2026-02-06_15h45_19" src="https://github.com/user-attachments/assets/351dae1c-a746-4ada-8e9f-3e609772e00b" />


## Algorithm

For full implementation details, see [MATH_TRACES_IMPLEMENTATION.md](https://github.com/user-attachments/files/25118444/MATH_TRACES_IMPLEMENTATION.md)

1. Collect all unique timestamps from all input series
2. For each timestamp, interpolate values from input series using `getValueAtTime()`
3. Skip timestamps that fall in large gaps (default: > 1 second)
4. Evaluate the parsed expression at each valid timestamp
5. Store computed points in output `MathDataSeries`