### PR TITLE
Support multi-select drag-and-drop of traces onto graphs

### DIFF
--- a/src/plot_widget.cpp
+++ b/src/plot_widget.cpp
@@ -1,4 +1,5 @@
 #include <QApplication>
+#include <QDataStream>
 #include <QMimeData>
 #include <QDockWidget>
 #include <QInputDialog>
@@ -793,21 +794,49 @@ void PlotWidget::dropEvent(QDropEvent *event)
         return;
     }
 
-    // DataSeries is dropped onto this PlotWidget
+    // One or more DataSeries are dropped onto this PlotWidget
     if (mime->hasFormat("source") && mime->hasFormat("series"))
     {
-        QString source_lbl = mime->data("source");
-        QString series_lbl = mime->data("series");
+        QStringList source_labels;
+        QStringList series_labels;
 
-        auto series = manager->findSeries(source_lbl, series_lbl);
+        QDataStream source_stream(mime->data("source"));
+        QDataStream series_stream(mime->data("series"));
 
-        if (series.isNull())
+        source_stream >> source_labels;
+        series_stream >> series_labels;
+
+        if (source_labels.isEmpty() || source_labels.count() != series_labels.count())
         {
-            qCritical() << "Could not find graph matching" << source_lbl << ":" << series_lbl;
             return;
         }
 
-        addSeries(series, QwtPlot::yLeft);
+        bool added_any = false;
+
+        for (int ii = 0; ii < source_labels.count(); ii++)
+        {
+            auto series = manager->findSeries(source_labels.at(ii), series_labels.at(ii));
+
+            if (series.isNull())
+            {
+                qCritical() << "Could not find graph matching" << source_labels.at(ii) << ":" << series_labels.at(ii);
+                continue;
+            }
+
+            // Defer the replot until all dropped series have been added
+            if (addSeries(series, QwtPlot::yLeft, false))
+            {
+                added_any = true;
+            }
+        }
+
+        if (added_any)
+        {
+            setAutoReplot(true);
+            replot();
+
+            updateTimestampLimits();
+        }
 
         event->accept();
     }
@@ -1604,7 +1633,7 @@ void PlotWidget::updateCursorShape(QMouseEvent *event)
  * @param axis_id - axis ID (either QwtPlot::yLeft or QwtPlot::yRight)
  * @return true if the series was added
  */
-bool PlotWidget::addSeries(DataSeriesPointer series, int axis_id)
+bool PlotWidget::addSeries(DataSeriesPointer series, int axis_id, bool do_replot)
 {
     if (series.isNull()) return false;
 
@@ -1633,10 +1662,13 @@ bool PlotWidget::addSeries(DataSeriesPointer series, int axis_id)
     // Perform initial data sampling
     curve->resampleData(interval.minValue(), interval.maxValue(), getHorizontalPixels());
 
-    setAutoReplot(true);
-    replot();
+    if (do_replot)
+    {
+        setAutoReplot(true);
+        replot();
 
-    updateTimestampLimits();
+        updateTimestampLimits();
+    }
 
     return true;
 }

--- a/src/plot_widget.hpp
+++ b/src/plot_widget.hpp
@@ -54,7 +54,7 @@ signals:
 public slots:
     int getHorizontalPixels(void) const;
 
-    bool addSeries(DataSeriesPointer series, int axis_id = QwtPlot::yLeft);
+    bool addSeries(DataSeriesPointer series, int axis_id = QwtPlot::yLeft, bool do_replot = true);
     bool addSeries(DataSeries *series) { return addSeries(DataSeriesPointer(series)); }
 
     bool removeSeries(DataSeriesPointer series);

--- a/src/widgets/dataview_tree.cpp
+++ b/src/widgets/dataview_tree.cpp
@@ -1,3 +1,4 @@
+#include <QDataStream>
 #include <QDrag>
 #include <QMimeData>
 #include <qmenu.h>
@@ -51,7 +52,7 @@ void DataViewTree::setupTree()
     setDragEnabled(true);
     setDragDropMode(QAbstractItemView::DragDropMode::DragDrop);
 
-    setSelectionMode(QAbstractItemView::SelectionMode::SingleSelection);
+    setSelectionMode(QAbstractItemView::SelectionMode::ExtendedSelection);
     setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
 
     header()->setSectionResizeMode(0, QHeaderView::Fixed);
@@ -322,40 +323,46 @@ int DataViewTree::refresh(QString filters)
  */
 void DataViewTree::startDrag(Qt::DropActions supported_actions)
 {
-    // TODO
     auto items = selectedItems();
 
-    // Only allow dragging for single items
-    if (items.count() != 1)
+    // Extract source / series information for each selected DataSeries item
+    QStringList source_labels;
+    QStringList series_labels;
+
+    for (auto *item : items)
+    {
+        if (!item) continue;
+
+        auto *parent = item->parent();
+
+        // Prevent top-level items (data sources) from being dragged
+        if (!parent) continue;
+
+        source_labels << parent->text(1);
+        series_labels << item->text(1);
+    }
+
+    // Nothing draggable was selected (e.g. only data sources were selected)
+    if (source_labels.isEmpty())
     {
         return;
     }
 
-    auto *item = items.at(0);
+    QByteArray source_data;
+    QByteArray series_data;
 
-    // null check
-    if (!item) return;
+    QDataStream source_stream(&source_data, QIODevice::WriteOnly);
+    QDataStream series_stream(&series_data, QIODevice::WriteOnly);
 
-    auto *parent = item->parent();
-
-    // Prevent top-level items from being dragged
-    if (!parent)
-    {
-        return;
-    }
-
-    // Extract source / series information from the item being dragged
-    // TODO : A better way of implementing this maybe?
-
-    QString series_label = item->text(1);
-    QString source_label = parent->text(1);
+    source_stream << source_labels;
+    series_stream << series_labels;
 
     QDrag *dragger = new QDrag(this);
 
     auto *mime = new QMimeData();
 
-    mime->setData("source", source_label.toLatin1());
-    mime->setData("series", series_label.toLatin1());
+    mime->setData("source", source_data);
+    mime->setData("series", series_data);
 
     dragger->setMimeData(mime);
 


### PR DESCRIPTION
## Summary
- Data view tree now uses ExtendedSelection so shift/ctrl-click selects multiple series
- Dragging the selection onto a plot adds all selected traces in a single drop (previously only the first)

## Test plan
- Rebuilt and manually verified: multi-select in data view + drag onto graph adds all selected traces