### PR TITLE
Harden dynamic plugin loading against incompatible plugins

### DIFF
--- a/src/plugins/plugin_registry.cpp
+++ b/src/plugins/plugin_registry.cpp
@@ -3,7 +3,10 @@
 #include <QFileDialog>
 #include <QDialog>
 #include <QPluginLoader>
+#include <QLibrary>
 #include <QDir>
+#include <QDebug>
+#include <QJsonObject>
 
 #include "plugin_registry.hpp"
 #include "lumberjack_settings.hpp"
@@ -13,6 +16,56 @@
 #include "plugins/csv_exporter/lumberjack_csv_exporter.hpp"
 #include "plugins/offset_filter/offset_filter.hpp"
 #include "plugins/scaler_filter/scaler_filter.hpp"
+
+/**
+ * @brief Check whether a plugin was built against the same Qt version and
+ * build type (debug/release) as this application.
+ *
+ * QPluginLoader/QLibrary's own compatibility check is coarser than this: it can
+ * accept a plugin built against a different (but "close enough") Qt version, and
+ * does not reliably reject a debug/release mismatch on every platform. Loading an
+ * ABI-incompatible plugin doesn't fail cleanly in that case - it corrupts memory
+ * the moment the plugin's code actually runs. Require an exact match instead.
+ */
+static bool isPluginCompatible(const QString &pluginPath)
+{
+    QPluginLoader loader(pluginPath);
+
+    QJsonObject metaData = loader.metaData();
+
+    if (metaData.isEmpty())
+    {
+        // Not a Qt plugin at all
+        return false;
+    }
+
+#if defined(QT_NO_DEBUG)
+    const bool hostIsDebugBuild = false;
+#else
+    const bool hostIsDebugBuild = true;
+#endif
+
+    const int pluginVersion = metaData.value("version").toInt();
+    const bool pluginIsDebugBuild = metaData.value("debug").toBool();
+
+    if (pluginVersion != QT_VERSION || pluginIsDebugBuild != hostIsDebugBuild)
+    {
+        qWarning().noquote() << QString(
+            "Skipping incompatible plugin '%1': built against Qt %2.%3.%4 (%5), "
+            "but this application is Qt %6 (%7)")
+            .arg(pluginPath)
+            .arg((pluginVersion >> 16) & 0xFF)
+            .arg((pluginVersion >> 8) & 0xFF)
+            .arg(pluginVersion & 0xFF)
+            .arg(pluginIsDebugBuild ? "debug" : "release")
+            .arg(QT_VERSION_STR)
+            .arg(hostIsDebugBuild ? "debug" : "release");
+
+        return false;
+    }
+
+    return true;
+}
 
 PluginRegistry* PluginRegistry::instance = 0;
 
@@ -69,11 +122,23 @@ void PluginRegistry::loadPlugins()
 
         for (QString libFile : libDir.entryList(QDir::Files))
         {
-            QString libPath = libDir.absoluteFilePath(libFile);
+            QString pluginPath = libDir.absoluteFilePath(libFile);
 
-            QPluginLoader loader(libPath);
+            // Skip anything that isn't a shared library (e.g. our own .exe,
+            // Qt/runtime DLLs sitting alongside it, stray non-binary files)
+            if (!QLibrary::isLibrary(pluginPath)) continue;
+
+            if (!isPluginCompatible(pluginPath)) continue;
+
+            QPluginLoader loader(pluginPath);
 
             QObject *instance = loader.instance();
+
+            if (!instance)
+            {
+                qWarning() << "Failed to load plugin" << pluginPath << ":" << loader.errorString();
+                continue;
+            }
 
             // Try to load against each type of plugin interface
             if      (loadImportPlugin(instance)) {}
@@ -81,8 +146,11 @@ void PluginRegistry::loadPlugins()
             else if (loadFilterPlugin(instance)) {}
             else
             {
-                // No match for the plugin
-                delete instance;
+                // Loaded successfully, but doesn't implement a known interface.
+                // The instance is owned by QPluginLoader - don't delete it ourselves,
+                // just unload the library.
+                qWarning() << "Plugin" << pluginPath << "does not implement a known plugin interface";
+                loader.unload();
             }
         }
     }


### PR DESCRIPTION
## Summary
- PluginRegistry::loadPlugins() scanned every file in each Qt library path (including the app's own .exe and unrelated runtime DLLs) and handed each one to QPluginLoader unconditionally.
- Qt's own plugin compatibility check is coarse: a plugin built against a close-but-different Qt version/build-type can pass it and be returned as a live instance, then corrupt memory the moment its code actually runs instead of failing to load cleanly. This was reproduced concretely with a release plugin built against Qt 6.8.0 loaded into a debug Qt 6.8.3 host - it crashed on Import Data.
- The "no match" branch also called delete instance on an object still owned by QPluginLoader, which is unsafe.

## Changes
- Skip non-library files up front via QLibrary::isLibrary().
- Added isPluginCompatible(): reads the plugin's embedded Qt version + debug/release flag via QPluginLoader::metaData() (safe - doesn't touch the plugin's compiled code) and requires an exact match against the host build before ever calling instance().
- Log a warning when a plugin is skipped or fails to load, instead of failing silently.
- Replaced the unsafe delete instance with loader.unload() for plugins that load but don't implement a known interface.

## Test plan
- [x] Built and ran against Qt 6.8.3 (debug) with the incompatible plugin present - previously crashed 100% of the time on Import Data, now runs cleanly across multiple runs.
- [x] Confirmed via debugger that the incompatible plugin is excluded (m_ImportPlugins.count() == 1, builtin CSV importer only) and that a warning is logged with the correct plugin path, versions, and build types.
- [x] Confirmed the import flow proceeds past the previous crash point.
- [x] Confirmed built-in plugins (CSV import/export, offset/scaler filters) are unaffected.